### PR TITLE
Increase compatibility with Oracle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.aconex.scrutineer</groupId>
     <artifactId>scrutineer</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Scrutineer (Stream Comparator)</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>0.90.2</version>
+            <version>1.5.0</version>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>

--- a/src/main/java/com/aconex/scrutineer/jdbc/IdAndVersionResultSetIterator.java
+++ b/src/main/java/com/aconex/scrutineer/jdbc/IdAndVersionResultSetIterator.java
@@ -58,6 +58,7 @@ public class IdAndVersionResultSetIterator implements Iterator<IdAndVersion> {
         switch (this.idColumnType) {
         case Types.BIGINT:
         case Types.INTEGER:
+        case Types.NUMERIC:
             return resultSet.getLong(1);
         default:
             return resultSet.getString(1);
@@ -72,6 +73,7 @@ public class IdAndVersionResultSetIterator implements Iterator<IdAndVersion> {
 
             case Types.BIGINT:
             case Types.INTEGER:
+            case Types.NUMERIC:
                 return resultSet.getLong(2);
             default:
                 throw new UnsupportedOperationException(String.format("Do not know how to handle version column type (java.sql.Type value=%d", versionColumnType));


### PR DESCRIPTION
Oracle db returns columns with integers as DbType.NUMERIC. Added this. Now scrutineer can also work with Oracle DB.
Also upgraded elasticsearch client to 1.5.0