### PR TITLE
Uplift Elasticsearch to 1.7.6 initially, and align the project versio…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.aconex.scrutineer</groupId>
     <artifactId>scrutineer</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.7.6-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Scrutineer (Stream Comparator)</name>
     <description>
@@ -80,6 +80,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.25</slf4j.version>
+        <elasticsearch.version>1.7.6</elasticsearch.version>
     </properties>
 
     <dependencies>
@@ -97,7 +98,7 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>1.5.0</version>
+            <version>${elasticsearch.version}</version>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>

--- a/src/test/java/com/aconex/scrutineer/functional/ScrutineerIntegrationTest.java
+++ b/src/test/java/com/aconex/scrutineer/functional/ScrutineerIntegrationTest.java
@@ -1,5 +1,14 @@
 package com.aconex.scrutineer.functional;
 
+import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
+import static org.mockito.Mockito.verify;
+
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.net.URL;
+import java.util.TimeZone;
+import javax.sql.DataSource;
+
 import com.aconex.scrutineer.Scrutineer;
 import com.aconex.scrutineer.elasticsearch.ElasticSearchTestHelper;
 import com.aconex.scrutineer.jdbc.HSQLHelper;
@@ -15,15 +24,6 @@ import org.elasticsearch.common.joda.time.DateTimeZone;
 import org.elasticsearch.node.Node;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
-import javax.sql.DataSource;
-import java.io.InputStream;
-import java.io.PrintStream;
-import java.net.URL;
-import java.util.TimeZone;
-
-import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
-import static org.mockito.Mockito.verify;
 
 public class ScrutineerIntegrationTest extends DataSourceBasedDBTestCase {
 
@@ -89,7 +89,7 @@ public class ScrutineerIntegrationTest extends DataSourceBasedDBTestCase {
         BulkRequest bulkRequest = new BulkRequestBuilder(client).request();
         URL bulkIndexRequest = this.getClass().getResource("es-bulkindex.json");
         byte[] data = ByteStreams.toByteArray(bulkIndexRequest.openStream());
-        bulkRequest.add(data, 0, data.length, true);
+        bulkRequest.add(data, 0, data.length);
         BulkResponse bulkResponse = client.bulk(bulkRequest).actionGet();
         if (bulkResponse.hasFailures()) {
             throw new RuntimeException("Failed to index data needed for test. " + bulkResponse.buildFailureMessage());

--- a/src/test/java/com/aconex/scrutineer/functional/ScrutineerNumericIntegrationTest.java
+++ b/src/test/java/com/aconex/scrutineer/functional/ScrutineerNumericIntegrationTest.java
@@ -87,7 +87,7 @@ public class ScrutineerNumericIntegrationTest extends DataSourceBasedDBTestCase 
         BulkRequest bulkRequest = new BulkRequestBuilder(client).request();
         URL bulkIndexRequest = this.getClass().getResource("es-numericbulkindex.json");
         byte[] data = ByteStreams.toByteArray(bulkIndexRequest.openStream());
-        bulkRequest.add(data, 0, data.length, true);
+        bulkRequest.add(data, 0, data.length);
         BulkResponse bulkResponse = client.bulk(bulkRequest).actionGet();
         if (bulkResponse.hasFailures()) {
             throw new RuntimeException("Failed to index data needed for test. " + bulkResponse.buildFailureMessage());


### PR DESCRIPTION
Part of Issue #31, this change brings Scrutineer up to supporting ES version 1.7.6 which is a stepping stone along the journey up to 6.5..