### PR TITLE
48 es to es comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Scrutineer 7.9.4
 * introduced a new scrutineer executable `scrutineer2` which reads the configurations from two manifest files, e.g:
   `scrutineer/target/appassembler/bin/scrutineer2 --primary-config=jdbc.properties --secondary-config=elasticsearch7.properties --numeric`
 
+* enabled elasticsearch vs elasticsearch comparison
+
 Scrutineer 6.8.x
 -----------------
 *BREAKING* 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Scrutineer 7.9.4
 * introduced a new scrutineer executable `scrutineer2` which reads the configurations from two manifest files, e.g:
   `scrutineer/target/appassembler/bin/scrutineer2 --primary-config=jdbc.properties --secondary-config=elasticsearch7.properties --numeric`
 
-* enabled elasticsearch vs elasticsearch comparison
+* enabled elasticsearch vs elasticsearch comparison, you simply provide two Elasticsearch configurations
 
 Scrutineer 6.8.x
 -----------------

--- a/scrutineer/src/main/java/com/aconex/scrutineer/ScrutineerCommandLineOptionsExtension.java
+++ b/scrutineer/src/main/java/com/aconex/scrutineer/ScrutineerCommandLineOptionsExtension.java
@@ -1,5 +1,7 @@
 package com.aconex.scrutineer;
 
+import static java.util.Collections.unmodifiableMap;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -8,7 +10,6 @@ import com.aconex.scrutineer.config.ConnectorConfig;
 import com.aconex.scrutineer.elasticsearch.v7.ElasticSearchConnectorConfig;
 import com.aconex.scrutineer.elasticsearch.v7.TransportAddressParser;
 import com.aconex.scrutineer.jdbc.JdbcConnectorConfig;
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Provide scrutineer and stream configurations via through a ScrutineerCommandLineOptions delegate, this class
@@ -51,7 +52,7 @@ public class ScrutineerCommandLineOptionsExtension implements ConfigurationProvi
         props.put(JdbcConnectorConfig.CONFIG_JDBC_SQL, commandLineOptions.sql);
         props.put(JdbcConnectorConfig.CONFIG_JDBC_USER, commandLineOptions.jdbcUser);
         props.put(JdbcConnectorConfig.CONFIG_JDBC_PASSWORD, commandLineOptions.jdbcPassword);
-        return ImmutableMap.copyOf(props);
+        return unmodifiableMap(props);
     }
 
     @Override
@@ -67,7 +68,7 @@ public class ScrutineerCommandLineOptionsExtension implements ConfigurationProvi
         props.put(ElasticSearchConnectorConfig.CONFIG_ES_INDEX_NAME, commandLineOptions.indexName);
         props.put(ElasticSearchConnectorConfig.CONFIG_ES_QUERY, commandLineOptions.query);
 
-        return ImmutableMap.copyOf(props);
+        return unmodifiableMap(props);
     }
 
     private Map<String, String> initProperties(String connectorClass) {

--- a/scrutineer/src/test/java/com/aconex/scrutineer/elasticsearch/ESIntegrationTestNode.java
+++ b/scrutineer/src/test/java/com/aconex/scrutineer/elasticsearch/ESIntegrationTestNode.java
@@ -21,16 +21,21 @@ public class ESIntegrationTestNode extends Node {
     }
 
     public static Node elasticSearchTestNode() throws NodeValidationException {
-        return elasticSearchTestNode(CLUSTER_NAME);
+        return elasticSearchTestNode(CLUSTER_NAME, 9300);
     }
 
     public static Node elasticSearchTestNode(String clusterName) throws NodeValidationException {
+        return elasticSearchTestNode(clusterName, 9300);
+    }
+
+    public static Node elasticSearchTestNode(String clusterName, int tcpPort) throws NodeValidationException {
         Node node = new ESIntegrationTestNode(
                 Settings.builder()
                         .put("cluster.name", clusterName)
                         .put("transport.type", "netty4")
+                        .put("transport.tcp.port", tcpPort + "")
                         .put("http.type", "netty4")
-                        .put("path.home", "data")
+                        .put("path.home", "data/" + clusterName)
                         .put("node.name", TEST_NODE_NAME)
                         .build(),
                 asList(Netty4Plugin.class));

--- a/scrutineer/src/test/java/com/aconex/scrutineer/functional/Scrutineer2IntegrationTest.java
+++ b/scrutineer/src/test/java/com/aconex/scrutineer/functional/Scrutineer2IntegrationTest.java
@@ -1,21 +1,57 @@
 package com.aconex.scrutineer.functional;
 
+import static org.elasticsearch.common.xcontent.XContentType.JSON;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.net.URL;
 import java.util.TimeZone;
 
+import javax.sql.DataSource;
+
+import com.aconex.scrutineer.elasticsearch.ESIntegrationTestNode;
+import com.aconex.scrutineer.elasticsearch.ElasticSearchTestHelper;
+import com.aconex.scrutineer.jdbc.HSQLHelper;
 import com.aconex.scrutineer.v2.Scrutineer2;
+import com.google.common.io.ByteStreams;
+import org.dbunit.DataSourceBasedDBTestCase;
+import org.dbunit.dataset.IDataSet;
+import org.dbunit.dataset.xml.XmlDataSet;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.node.NodeValidationException;
 import org.joda.time.DateTimeZone;
+import org.mockito.MockitoAnnotations;
 
-public class Scrutineer2IntegrationTest extends ScrutineerIntegrationTest {
+public class Scrutineer2IntegrationTest extends DataSourceBasedDBTestCase {
+    private static final String CLUSTER1_NAME = "scrutineer2integrationtest1";
+    private static final String CLUSTER2_NAME = "scrutineer2integrationtest2";
 
-    @Override
-    public void testShouldScrutinizeStreamsEffectively() {
+
+    private HSQLHelper hsqlHelper = new HSQLHelper();
+    private Node node1;
+    private Node node2;
+    private Client client1;
+    private Client client2;
+
+    PrintStream printStream = spy(System.err);
+
+    public void testShouldScrutinizeJdbcAndElasticSearchStreamsEffectively() throws Exception {
+        setupElasticSearchConnection1(CLUSTER1_NAME, 9300);
+        indexSetupStateForElasticSearchCluster(client1, "test", "es-bulkindex.json");
 
         TimeZone.setDefault(TimeZone.getTimeZone("GST"));
         DateTimeZone.setDefault(DateTimeZone.forOffsetHours(4));
 
         String[] args = {
                 "--primary-config", "test-jdbc-config.properties",
-                "--secondary-config", "test-elasticsearch7-config.properties",
+                "--secondary-config", "test-elasticsearch7-cluster1-config.properties",
                 "--versions-as-timestamps"
         };
 
@@ -26,4 +62,107 @@ public class Scrutineer2IntegrationTest extends ScrutineerIntegrationTest {
 
         verifyThatErrorsWrittenToStandardError(printStream);
     }
+
+
+    public void testShouldScrutinizeTwoElasticSearchStreamsEffectively() throws Exception {
+        setupElasticSearchConnection1(CLUSTER1_NAME, 9300);
+        setupElasticSearchConnection2(CLUSTER2_NAME, 9301);
+        indexSetupStateForElasticSearchCluster(client1, "test", "es-bulkindex.json");
+        indexSetupStateForElasticSearchCluster(client2, "test2", "es-bulkindex-2.json");
+
+        TimeZone.setDefault(TimeZone.getTimeZone("GST"));
+        DateTimeZone.setDefault(DateTimeZone.forOffsetHours(4));
+
+
+        String[] args = {
+                "--primary-config", "test-elasticsearch7-cluster2-config.properties",
+                "--secondary-config", "test-elasticsearch7-cluster1-config.properties",
+                "--versions-as-timestamps"
+        };
+
+
+        System.setErr(printStream);
+
+        Scrutineer2.main(args);
+
+        verifyThatErrorsWrittenToStandardError(printStream);
+    }
+
+    protected void verifyThatErrorsWrittenToStandardError(PrintStream printStream) {
+        verify(printStream).println("NOTINSECONDARY\t2\t20(1970-01-01T04:00:00.020+04:00)");
+        verify(printStream).println("MISMATCH\t3\t30(1970-01-01T04:00:00.030+04:00)\tsecondaryVersion=42(1970-01-01T04:00:00.042+04:00)");
+        verify(printStream).println("NOTINPRIMARY\t4\t40(1970-01-01T04:00:00.040+04:00)");
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        setupHSQLDB();
+        super.setUp();
+    }
+
+    private void setupElasticSearchConnection1(String clusterName, int port) throws NodeValidationException {
+        this.node1 = ESIntegrationTestNode.elasticSearchTestNode(clusterName, port);
+        this.client1 = node1.client();
+    }
+
+    private void setupElasticSearchConnection2(String cluster2Name, int port) throws NodeValidationException {
+        this.node2 = ESIntegrationTestNode.elasticSearchTestNode(cluster2Name, port);
+        this.client2 = node2.client();
+    }
+
+    private void setupHSQLDB() throws Exception {
+        hsqlHelper = new HSQLHelper();
+        hsqlHelper.createHsqldbTables(getDataSet(), getDataSource().getConnection());
+    }
+
+
+    private void indexSetupStateForElasticSearchCluster(Client client, String indexName, String bulkIndexFileName) throws Exception {
+        new ElasticSearchTestHelper(client).deleteIndexIfItExists(indexName);
+        BulkRequestBuilder bulkRequest = client.prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        URL bulkIndexRequest = this.getClass().getResource(bulkIndexFileName);
+        byte[] data = ByteStreams.toByteArray(bulkIndexRequest.openStream());
+        bulkRequest.add(data, 0, data.length, JSON);
+        BulkResponse bulkResponse = bulkRequest.get();
+        if (bulkResponse.hasFailures()) {
+            throw new RuntimeException("Failed to index data needed for test. " + bulkResponse.buildFailureMessage());
+        }
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        hsqlHelper.shutdownHSQL(getDataSource());
+        closeElasticSearch();
+    }
+
+    private void closeElasticSearch() throws IOException {
+        if (client1 != null) {
+            client1.close();
+        }
+        if (node1 != null) {
+            node1.close();
+        }
+
+        if (client2 != null) {
+            client2.close();
+        }
+        if (node2 != null) {
+            node2.close();
+        }
+    }
+
+
+    @Override
+    protected DataSource getDataSource() {
+        return hsqlHelper.setupHSQLDBDataSource();
+    }
+
+    @Override
+    protected IDataSet getDataSet() throws Exception {
+        InputStream resourceAsStream = this.getClass().getResourceAsStream("fullintegrationtest.xml");
+        return new XmlDataSet(resourceAsStream);
+
+    }
+
 }

--- a/scrutineer/src/test/resources/com/aconex/scrutineer/functional/es-bulkindex-2.json
+++ b/scrutineer/src/test/resources/com/aconex/scrutineer/functional/es-bulkindex-2.json
@@ -1,0 +1,6 @@
+{ "index" : { "_index" : "test2", "_type" : "task", "_id" : "1" , "version_type": "external", "version": 10} }
+{}
+{ "index" : { "_index" : "test2", "_type" : "task", "_id" : "2" , "version_type": "external", "version": 20} }
+{}
+{ "index" : { "_index" : "test2", "_type" : "task", "_id" : "3" , "version_type": "external", "version": 30} }
+{}

--- a/scrutineer/src/test/resources/test-elasticsearch7-cluster1-config.properties
+++ b/scrutineer/src/test/resources/test-elasticsearch7-cluster1-config.properties
@@ -1,0 +1,9 @@
+stream.connector.class=com.aconex.scrutineer.elasticsearch.v7.ElasticSearchStreamConnector
+es.cluster.name=scrutineer2integrationtest1
+es.hosts=localhost:9300
+es.index.name=test
+es.query=*
+es.ssl.enabled=false
+# es.username=user
+# es.password=secret
+# es.ssl.verification.mode=certificate

--- a/scrutineer/src/test/resources/test-elasticsearch7-cluster2-config.properties
+++ b/scrutineer/src/test/resources/test-elasticsearch7-cluster2-config.properties
@@ -1,7 +1,7 @@
 stream.connector.class=com.aconex.scrutineer.elasticsearch.v7.ElasticSearchStreamConnector
-es.cluster.name=scrutineerintegrationtest
-es.hosts=localhost:9300
-es.index.name=test
+es.cluster.name=scrutineer2integrationtest2
+es.hosts=localhost:9301
+es.index.name=test2
 es.query=*
 es.ssl.enabled=false
 # es.username=user


### PR DESCRIPTION
## Proposed changes
Fixed a simply bug where two elasticsearch streams will download to the same temp file and causing conflict. This MR will help us officially support Elasticsearch to Elasticsearch comparison 

I've also isolated Scrutineer2 integration test to the old Scrutineer Integration test, the new one will grow independently now

**This addresses issue #48**



## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I've read the [CONTRIBUTING](https://github.com/Aconex/scrutineer/blob/master/CONTRIBUTING.md) doc
- [x] All tests pass locally with my changes
- [x] I've added unit tests and integration tests.
- [x] I've added necessary documentation (if appropriate)

## Further comments
This MR fix a bug and enabled #48 part 1, Elasticsearch to Elasticsearch comparison. Maybe we close #48 and open another ticket to address how to fix the differences (this itself can be a big task, depending on what level we want to support)