### PR TITLE
#65  ArtifactId  changes to differentiate old & new Scrutineer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Scrutineer Changelog
 
 Outlines key changes across versions (not exhaustive)
 
+Scrutineer2 1.0.0
+------------------
+* Completely new `artifactId` to distinguish the change in Connector model, and independent version numbering
+
+=================================
+
 Scrutineer 7.9.4
 -----------------
 * the single scrutineer jar was broken into different modules, `core`/`verifier` contain the foundational code and verification

--- a/README.md
+++ b/README.md
@@ -229,14 +229,17 @@ simple to add further integration points for other Primary & Secondary sources (
 
 Version Numbering/Compatibility
 ===============================
-The `scrutineer` version number (of the artifact/jar) is numbered to align with the underlying Elasticsearch version
-it is built against.    For example, `scrutineer-6.8.13` was build & linked against `elasticsearch-6.8.13`.  Generally
-this means the compatibility of scrutineer matches Elasticsearch's major version. ie. `scrutineer-6.8.13` really
-should work with any Elasticsearch version `6.x`.
+In 2021 we introduced `scrutineer2` which decoupled the underlying Connectors from the main verification library. The
+previous `scrutineer` code's version number was intrinsincly linked to the Elasticsearch version.  Since we watned
+to be able to source data from different sources, it was important to decouple the Connector from the Verification process
+that Scrutineer provided.
 
-If there are patches/bug fixes/changes that are _independent_ of the Elasticsearch version, then Scrutineer version
-numbers will include a "patch number".  For example, `scrutineer-6.8.13-4` is the 4th patch release of Scrutineer
-since aligning with Elasticsearch v6.8.13.
+`scrutineer2` therefore has its own version number independent of the connectors.  The underlying Connector, however, 
+could be versioned against it's respective related version (e.g. related to the ES version it supports.) 
+
+Connectors can therefore be upgraded independently.  `scrutineer2` own version might be bumped to bring in upgraded 
+Connectors, or because of other underlying fixes in the verification library.  
+
 
 JDBC Drivers
 ============

--- a/README.md
+++ b/README.md
@@ -230,12 +230,11 @@ simple to add further integration points for other Primary & Secondary sources (
 Version Numbering/Compatibility
 ===============================
 In 2021 we introduced `scrutineer2` which decoupled the underlying Connectors from the main verification library. The
-previous `scrutineer` code's version number was intrinsincly linked to the Elasticsearch version.  Since we watned
+previous `scrutineer` code's version number was intrinsically linked to the Elasticsearch version.  Since we wanted
 to be able to source data from different sources, it was important to decouple the Connector from the Verification process
 that Scrutineer provided.
 
-`scrutineer2` therefore has its own version number independent of the connectors.  The underlying Connector, however, 
-could be versioned against it's respective related version (e.g. related to the ES version it supports.) 
+`scrutineer2` therefore has its own version number independent of any underlying connected product version.  
 
 Connectors can therefore be upgraded independently.  `scrutineer2` own version might be bumped to bring in upgraded 
 Connectors, or because of other underlying fixes in the verification library.  

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -9,8 +9,8 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>scrutineer-core</artifactId>
-    <name>Scrutineer Core</name>
+    <artifactId>scrutineer2-core</artifactId>
+    <name>Scrutineer2 Core</name>
 
     <properties>
         <main.basedir>${project.basedir}/..</main.basedir>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,9 +3,9 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
+        <artifactId>scrutineer2-pom</artifactId>
         <groupId>com.aconex.scrutineer</groupId>
-        <artifactId>scrutineer-pom</artifactId>
-        <version>7.9.4-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,14 +2,16 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress>
         <notes><![CDATA[
-   file name: elasticsearch7-0.0.1-SNAPSHOT.jar
+   Prevents OWASP Dependency checking picking up our Elasticsearch7 module as a "real" ES module
+   and painting it as outdated/vulnerable
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.aconex\.scrutineer/elasticsearch7@.*$</packageUrl>
         <cpe>cpe:/a:elastic:elasticsearch</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-   file name: elasticsearch7-0.0.1-SNAPSHOT.jar
+   Prevents OWASP Dependency checking picking up our Elasticsearch7 module as a "real" ES module
+   and painting it as outdated/vulnerable
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.aconex\.scrutineer/elasticsearch7@.*$</packageUrl>
         <cpe>cpe:/a:elasticsearch:elasticsearch</cpe>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+   file name: elasticsearch7-0.0.1-SNAPSHOT.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.aconex\.scrutineer/elasticsearch7@.*$</packageUrl>
+        <cpe>cpe:/a:elastic:elasticsearch</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: elasticsearch7-0.0.1-SNAPSHOT.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.aconex\.scrutineer/elasticsearch7@.*$</packageUrl>
+        <cpe>cpe:/a:elasticsearch:elasticsearch</cpe>
+    </suppress>
+</suppressions>

--- a/elasticsearch7/pom.xml
+++ b/elasticsearch7/pom.xml
@@ -17,7 +17,7 @@
         <httpclient.version>4.5.13</httpclient.version>
         <elasticsearch.version>7.10.2</elasticsearch.version>
         <!-- Common CVSS vulnerabilities mean we often have to declare specific dependencies on ES's netty  -->
-        <netty.version>4.1.59.Final</netty.version>
+        <netty.version>4.1.67.Final</netty.version>
     </properties>
     <dependencies>
         <dependency>
@@ -65,13 +65,6 @@
             <version>1.27</version>
         </dependency>
         <!-- END CVSS overrides -->
-
-        <!-- this is referenced by Elasticsearch X-Pack plugin and needs to be updated due to CVS score -->
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${httpclient.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>com.fasterxml.util</groupId>

--- a/elasticsearch7/pom.xml
+++ b/elasticsearch7/pom.xml
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>com.aconex.scrutineer</groupId>
-            <artifactId>scrutineer-core</artifactId>
+            <artifactId>scrutineer2-core</artifactId>
         </dependency>
 
         <dependency>

--- a/elasticsearch7/pom.xml
+++ b/elasticsearch7/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <main.basedir>${project.basedir}/..</main.basedir>
         <httpclient.version>4.5.13</httpclient.version>
-        <elasticsearch.version>7.9.3</elasticsearch.version>
+        <elasticsearch.version>7.10.2</elasticsearch.version>
         <!-- Common CVSS vulnerabilities mean we often have to declare specific dependencies on ES's netty  -->
         <netty.version>4.1.59.Final</netty.version>
     </properties>

--- a/elasticsearch7/pom.xml
+++ b/elasticsearch7/pom.xml
@@ -3,9 +3,9 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>scrutineer-pom</artifactId>
+        <artifactId>scrutineer2-pom</artifactId>
         <groupId>com.aconex.scrutineer</groupId>
-        <version>7.9.4-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -19,7 +19,7 @@
     <dependencies>
         <dependency>
             <groupId>com.aconex.scrutineer</groupId>
-            <artifactId>scrutineer-core</artifactId>
+            <artifactId>scrutineer2-core</artifactId>
         </dependency>
 
         <dependency>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -3,9 +3,9 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>scrutineer-pom</artifactId>
+        <artifactId>scrutineer2-pom</artifactId>
         <groupId>com.aconex.scrutineer</groupId>
-        <version>7.9.4-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,7 @@
                 <configuration>
                     <failBuildOnCVSS>8</failBuildOnCVSS>
                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                    <suppressionFile>dependency-check-suppressions.xml</suppressionFile>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <dependencies>
             <dependency>
                 <groupId>${project.groupId}</groupId>
-                <artifactId>scrutineer-core</artifactId>
+                <artifactId>scrutineer2-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,8 +2,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.aconex.scrutineer</groupId>
-    <artifactId>scrutineer-pom</artifactId>
-    <version>7.9.4-SNAPSHOT</version>
+    <artifactId>scrutineer2-pom</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/scrutineer/pom.xml
+++ b/scrutineer/pom.xml
@@ -8,7 +8,7 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>scrutineer</artifactId>
+    <artifactId>scrutineer2</artifactId>
     <modelVersion>4.0.0</modelVersion>
 
     <name>Scrutineer (Stream Comparator) Commandline Runner</name>
@@ -20,7 +20,7 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>scrutineer-core</artifactId>
+            <artifactId>scrutineer2-core</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/scrutineer/pom.xml
+++ b/scrutineer/pom.xml
@@ -3,9 +3,9 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
+        <artifactId>scrutineer2-pom</artifactId>
         <groupId>com.aconex.scrutineer</groupId>
-        <artifactId>scrutineer-pom</artifactId>
-        <version>7.9.4-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>scrutineer</artifactId>

--- a/verifier/pom.xml
+++ b/verifier/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>verifier</artifactId>
-    <name>Scrutineer Verifier</name>
+    <name>Scrutineer2 Verifier</name>
     <description>
         Verification logic to compares 2 streams of Ids and Versions
     </description>
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>scrutineer-core</artifactId>
+            <artifactId>scrutineer2-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/verifier/pom.xml
+++ b/verifier/pom.xml
@@ -3,9 +3,9 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>scrutineer-pom</artifactId>
+        <artifactId>scrutineer2-pom</artifactId>
         <groupId>com.aconex.scrutineer</groupId>
-        <version>7.9.4-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
With the new connector model, it's important we differentiate the new structure of Scrutineer.  Because the structure change is so large, a new ArtifactId is created `scrutineer2` that all the modules participate in.  